### PR TITLE
Improve support of collection types (arguments + return values)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,148 +1,70 @@
 # AGENTS
 
-This document collects concrete, observed information an autonomous agent needs to work effectively with this repository.
-
-It only documents what is present in the repository. Do not assume other commands, tools, or conventions exist unless listed here.
+Concise reference for agents working on this repository. Only documents observed, current project facts and commands.
 
 ---
 
 ## Quick facts
 
-- Project name (composer): makomweb/tactix (composer.json:1-3)
-- Language: PHP (composer.json:24)
-- Required PHP version: ^8.2 (composer.json:24)
-- Type: library (composer.json:4)
-- PSR-4 autoload: `Tactix\` => `src/` (composer.json:6-10)
-- Dev autoload for tests: `Tactix\Tests\` => `tests/` (composer.json:11-15)
-- Key dependencies (composer.json:23-27): `nikic/php-parser`, `xmolecules/phpmolecules`
-- Dev dependencies (composer.json:28-31): `phpstan/phpstan`, `phpunit/phpunit`, `friendsofphp/php-cs-fixer`
+- Language: PHP (composer.json)
+- PHP requirement: ^8.2
+- Package: makomweb/tactix
+- PSR-4 autoload: `Tactix\` -> `src/`; tests autoload `Tactix\Tests\` -> `tests/`
+- Tests: PHPUnit (vendor/bin/phpunit)
+- Static analysis: PHPStan (phpstan.neon.dist)
+- Code style: php-cs-fixer (.php-cs-fixer.dist.php)
 
 ## Repo layout (observed)
 
-- src/
-  - Analyzer/ (many analyzers and helpers)
-  - Assert/
-  - AmbiguityException.php
-  - AttributeName.php
-  - AttributeNameFactory.php
-  - Check.php
-  - ClassViolationException.php
-  - FolderViolationException.php
-  - Forbidden.php
-  - IgnoreableTypes.php
-  - Violation.php
-  - ViolationException.php
-  - YieldViolations.php
+- src/ (library code)
+- tests/Unit (PHPUnit tests) and tests/Data (fixtures)
+- .github/workflows/app-ci.yaml (CI runs phpstan, php-cs-fixer, phpunit)
+- docker/ (docker/php/Dockerfile) — image built from php:8.4-cli, includes xdebug and composer
+- docker-compose.yml — service name: `tactix`, mounts repository at `/var/www/project`
+- Makefile — targets: build, up, down, test-container, shell
 
-- tests/
-  - Data/ (fixture classes used by unit tests)
-  - Unit/ (PHPUnit tests)
-  - bootstrap.php (tests/bootstrap.php:1-7)
+## Container-based workflow (what to use)
 
-- CI: .github/workflows/app-ci.yaml (runs phpstan, php-cs-fixer, phpunit)
-- phpstan.neon.dist (phpstan configuration)
-- phpunit.xml.dist (phpunit configuration and coverage reporting)
-- composer.json / composer.lock
-- .php-cs-fixer.dist.php (present)
+Observed, supported workflow to run tests in a container using standard tooling:
 
-## How to set up and run the project (observed commands)
+- Build image: make build
+- Start service: make up
+- Install deps (inside container): docker exec -u 1000 tactix sh -c 'cd /var/www/project && composer install --no-interaction'
+- Run tests (inside service): make test-container  OR docker exec -u 1000 tactix sh -c 'cd /var/www/project && vendor/bin/phpunit --configuration phpunit.xml.dist --testdox'
+- Open shell in running container: make shell
 
-1. Install dependencies
+Makefile runs `docker compose` so use Docker Compose v2+ (command: `docker compose ...`).
 
-- composer install --prefer-dist --no-scripts (used in GitHub Actions: .github/workflows/app-ci.yaml:34-35)
-- Locally: `composer install`
+Notes about the container setup:
 
-2. QA / style / tests (composer scripts defined in composer.json:scripts)
+- Service key in docker-compose.yml is `tactix` and container_name is `tactix`.
+- Repository is mounted at `/var/www/project` inside the container.
+- Container runs as UID 1000:GID 1001 (user: "1000:1001").
+- Dockerfile (docker/php/Dockerfile) is based on `php:8.4-cli`, installs xdebug and copies Composer binary from the composer image.
+- The compose service sets `XDEBUG_MODE=coverage` so PHPUnit can generate coverage when xdebug is present.
 
-- Run all QA tools: `composer qa` (composer.json:33-38)
-  - runs: `vendor/bin/phpstan analyse --memory-limit=1G`, `vendor/bin/php-cs-fixer fix`, `vendor/bin/phpunit`
-- Run static analyzer: `composer sa` → `vendor/bin/phpstan analyse --memory-limit=1G` (composer.json:39)
-- Run tests: `composer test` → `vendor/bin/phpunit` (composer.json:40)
-- Run code style fixer: `composer cs` → `vendor/bin/php-cs-fixer fix` (composer.json:41)
+## PHPUnit configuration
 
-Direct invocations (used by CI):
-- `vendor/bin/phpstan analyse` (.github/workflows/app-ci.yaml:37-38)
-- `vendor/bin/php-cs-fixer check` (.github/workflows/app-ci.yaml:40-41)
-- `vendor/bin/phpunit` (.github/workflows/app-ci.yaml:43-44)
+- PHPUnit configuration file: `phpunit.xml.dist`.
+- PHPUnit is configured to NOT stop on errors (stopOnError="false").
+- Tests bootstrap via `tests/bootstrap.php` which requires Composer autoloader; ensure dependencies installed before running tests.
 
-Notes:
-- CI sets `PHP_CS_FIXER_IGNORE_ENV=1` and `DATABASE_URL="sqlite:///:memory:"` (.github/workflows/app-ci.yaml:20-22)
-- PHPUnit bootstrap: `tests/bootstrap.php` (phpunit.xml.dist:8)
+## Commands (summary)
 
-## Testing patterns
+- Local composer install: `composer install`
+- Run tests locally (host): `composer test` (vendor/bin/phpunit)
+- Run QA: `composer qa` (phpstan, php-cs-fixer, phpunit)
+- Container build: `make build`
+- Container up: `make up`
+- Run tests in container: `make test-container` (invokes `docker compose run --rm tactix vendor/bin/phpunit ...`)
+- Shell into running container: `make shell`
 
-- PHPUnit is used (phpunit.xml.dist)
-- Tests are under `tests/Unit` and use PHPUnit attributes (e.g. `#[Test]`) (tests/Unit/*.php)
-- Test fixtures/live examples are in `tests/Data` and are loaded via composer autoloading (composer.json:11-15)
-- Tests expect thrown domain exceptions; e.g. `Check::className(...)` and `Check::folder(...)` throw `ClassViolationException` or `FolderViolationException` with a public `violations` property (see tests/Unit/* and src/Check.php:12-31)
+## Gotchas / important notes
 
-## Static analysis and code-style
-
-- phpstan: configured at max level in phpstan.neon.dist (phpstan.neon.dist:1-4)
-  - Paths analysed: src/ and tests/
-- php-cs-fixer: config file present (.php-cs-fixer.dist.php)
-- GitHub Actions run phpstan, php-cs-fixer check and phpunit (see .github/workflows/app-ci.yaml)
-
-## Key runtime behavior and patterns (observed in source)
-
-- Primary entry points (public API):
-  - Tactix\Check::className(string $className) (src/Check.php:12-19)
-  - Tactix\Check::folder(string $folder) (src/Check.php:24-31)
-
-- Both methods gather violations from `YieldViolations::fromClassName` / `YieldViolations::fromFolder` and throw exceptions when violations exist.
-  - Exceptions thrown: `Tactix\ClassViolationException` and `Tactix\FolderViolationException` (src/Check.php:14-30)
-  - Exception objects expose a `violations` property (tests assert on that)
-
-- Forbidden relations are modelled in `Tactix\Forbidden` (src/Forbidden.php). Important observed behavior:
-  - `Forbidden::check(AttributeName $from, AttributeName $to): bool` checks against a blacklist (src/Forbidden.php:19-27)
-  - If `from` is not present in the hard-coded blacklist, it throws a `LogicException` instructing to add an entry (src/Forbidden.php:27)
-  - The blacklist is created by `createBlackList()` and contains `AttributeName` enum-like constants such as `AttributeName::ENTITY`, `AttributeName::VALUE_OBJECT`, etc. (src/Forbidden.php:31-50)
-
-- Attribute / tag handling depends on external `xmolecules/phpmolecules` package (README usage, composer.json:25-26). Tests use attributes on fixture classes in `tests/Data`.
-
-- Analyzer implementation is under `src/Analyzer/` — multiple classes for parsing PHP files and reducing relations. Use these files when modifying or extending analysis.
-
-## Naming conventions and code-style patterns (observed)
-
-- PSR-4 namespaces: `Tactix\` for src/, `Tactix\Tests\` for tests (composer.json:6-14)
-- Strict types declaration: files declare `declare(strict_types=1);` (many files)
-- Readonly classes: some classes use `final readonly class` (src/Check.php:7)
-- Exceptions follow `*Exception` suffix and are placed in project root (e.g. `ClassViolationException.php`)
-- Test methods use descriptive names and `#[Test]` attribute (tests/Unit/*)
-
-## Files to inspect when making changes
-
-- Public API: `src/Check.php` (src/Check.php:7-31)
-- Violation models & exceptions: `src/Violation.php`, `src/ViolationException.php`, `src/ClassViolationException.php`, `src/FolderViolationException.php`
-- Forbidden rules: `src/Forbidden.php` (src/Forbidden.php:19-51)
-- Analyzer logic: `src/Analyzer/*` (multiple files)
-- Tests & fixtures: `tests/Unit/*`, `tests/Data/*`
-- CI workflow: `.github/workflows/app-ci.yaml`
-- Static analysis: `phpstan.neon.dist`
-- Composer scripts: `composer.json:scripts`
-
-## Gotchas and non-obvious observations (explicit)
-
-- `Forbidden::check` will throw a `LogicException` if a "from" `AttributeName` is not present in the hard-coded blacklist (src/Forbidden.php:27). If you add a new `AttributeName` you must also update the blacklist or handle the exception.
-
-- Composer `qa` script runs the fixer with `vendor/bin/php-cs-fixer fix` which will modify files in-place. CI runs `php-cs-fixer check` (app-ci.yaml:40) which only checks; the `composer qa` usage differs (fix vs check).
-
-- PHPUnit is configured to stop on error (phpunit.xml.dist:9) and has xdebug coverage settings enabled in the configuration file (phpunit.xml.dist:19-20).
-
-- Tests rely on autoloading and the test bootstrap `tests/bootstrap.php` which calls the Composer autoloader (tests/bootstrap.php:3). Ensure composer dependencies are installed before running tests.
-
-## What I searched for (discovery steps performed)
-
-- repo root listing (ls)
-- looked for agent/rule files: none found
-- composer.json (read for scripts, autoload, requirements)
-- phpunit.xml.dist (read for test config)
-- phpstan.neon.dist (read for static analysis config)
-- README.md (usage notes and examples)
-- .github/workflows/app-ci.yaml (CI steps)
-- representative source files: src/Check.php, src/Forbidden.php, src/Analyzer/*
-- tests: tests/Unit/* and tests/Data/*
+- If you add new AttributeName values, update the hard-coded blacklist in `src/Forbidden.php` or `Forbidden::check()` will throw a LogicException.
+- `composer qa` runs php-cs-fixer in "fix" mode (will modify files in-place); CI uses php-cs-fixer check.
+- The container workflow relies on the docker/php/Dockerfile. If you remove or change it, update docker-compose.yml accordingly.
 
 ---
 
-If you want this file updated (expanded, reorganized, or to include additional file:line references), run this command again and specify what to add.
+Update or extend this file only with facts observed in the repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,148 @@
+# AGENTS
+
+This document collects concrete, observed information an autonomous agent needs to work effectively with this repository.
+
+It only documents what is present in the repository. Do not assume other commands, tools, or conventions exist unless listed here.
+
+---
+
+## Quick facts
+
+- Project name (composer): makomweb/tactix (composer.json:1-3)
+- Language: PHP (composer.json:24)
+- Required PHP version: ^8.2 (composer.json:24)
+- Type: library (composer.json:4)
+- PSR-4 autoload: `Tactix\` => `src/` (composer.json:6-10)
+- Dev autoload for tests: `Tactix\Tests\` => `tests/` (composer.json:11-15)
+- Key dependencies (composer.json:23-27): `nikic/php-parser`, `xmolecules/phpmolecules`
+- Dev dependencies (composer.json:28-31): `phpstan/phpstan`, `phpunit/phpunit`, `friendsofphp/php-cs-fixer`
+
+## Repo layout (observed)
+
+- src/
+  - Analyzer/ (many analyzers and helpers)
+  - Assert/
+  - AmbiguityException.php
+  - AttributeName.php
+  - AttributeNameFactory.php
+  - Check.php
+  - ClassViolationException.php
+  - FolderViolationException.php
+  - Forbidden.php
+  - IgnoreableTypes.php
+  - Violation.php
+  - ViolationException.php
+  - YieldViolations.php
+
+- tests/
+  - Data/ (fixture classes used by unit tests)
+  - Unit/ (PHPUnit tests)
+  - bootstrap.php (tests/bootstrap.php:1-7)
+
+- CI: .github/workflows/app-ci.yaml (runs phpstan, php-cs-fixer, phpunit)
+- phpstan.neon.dist (phpstan configuration)
+- phpunit.xml.dist (phpunit configuration and coverage reporting)
+- composer.json / composer.lock
+- .php-cs-fixer.dist.php (present)
+
+## How to set up and run the project (observed commands)
+
+1. Install dependencies
+
+- composer install --prefer-dist --no-scripts (used in GitHub Actions: .github/workflows/app-ci.yaml:34-35)
+- Locally: `composer install`
+
+2. QA / style / tests (composer scripts defined in composer.json:scripts)
+
+- Run all QA tools: `composer qa` (composer.json:33-38)
+  - runs: `vendor/bin/phpstan analyse --memory-limit=1G`, `vendor/bin/php-cs-fixer fix`, `vendor/bin/phpunit`
+- Run static analyzer: `composer sa` → `vendor/bin/phpstan analyse --memory-limit=1G` (composer.json:39)
+- Run tests: `composer test` → `vendor/bin/phpunit` (composer.json:40)
+- Run code style fixer: `composer cs` → `vendor/bin/php-cs-fixer fix` (composer.json:41)
+
+Direct invocations (used by CI):
+- `vendor/bin/phpstan analyse` (.github/workflows/app-ci.yaml:37-38)
+- `vendor/bin/php-cs-fixer check` (.github/workflows/app-ci.yaml:40-41)
+- `vendor/bin/phpunit` (.github/workflows/app-ci.yaml:43-44)
+
+Notes:
+- CI sets `PHP_CS_FIXER_IGNORE_ENV=1` and `DATABASE_URL="sqlite:///:memory:"` (.github/workflows/app-ci.yaml:20-22)
+- PHPUnit bootstrap: `tests/bootstrap.php` (phpunit.xml.dist:8)
+
+## Testing patterns
+
+- PHPUnit is used (phpunit.xml.dist)
+- Tests are under `tests/Unit` and use PHPUnit attributes (e.g. `#[Test]`) (tests/Unit/*.php)
+- Test fixtures/live examples are in `tests/Data` and are loaded via composer autoloading (composer.json:11-15)
+- Tests expect thrown domain exceptions; e.g. `Check::className(...)` and `Check::folder(...)` throw `ClassViolationException` or `FolderViolationException` with a public `violations` property (see tests/Unit/* and src/Check.php:12-31)
+
+## Static analysis and code-style
+
+- phpstan: configured at max level in phpstan.neon.dist (phpstan.neon.dist:1-4)
+  - Paths analysed: src/ and tests/
+- php-cs-fixer: config file present (.php-cs-fixer.dist.php)
+- GitHub Actions run phpstan, php-cs-fixer check and phpunit (see .github/workflows/app-ci.yaml)
+
+## Key runtime behavior and patterns (observed in source)
+
+- Primary entry points (public API):
+  - Tactix\Check::className(string $className) (src/Check.php:12-19)
+  - Tactix\Check::folder(string $folder) (src/Check.php:24-31)
+
+- Both methods gather violations from `YieldViolations::fromClassName` / `YieldViolations::fromFolder` and throw exceptions when violations exist.
+  - Exceptions thrown: `Tactix\ClassViolationException` and `Tactix\FolderViolationException` (src/Check.php:14-30)
+  - Exception objects expose a `violations` property (tests assert on that)
+
+- Forbidden relations are modelled in `Tactix\Forbidden` (src/Forbidden.php). Important observed behavior:
+  - `Forbidden::check(AttributeName $from, AttributeName $to): bool` checks against a blacklist (src/Forbidden.php:19-27)
+  - If `from` is not present in the hard-coded blacklist, it throws a `LogicException` instructing to add an entry (src/Forbidden.php:27)
+  - The blacklist is created by `createBlackList()` and contains `AttributeName` enum-like constants such as `AttributeName::ENTITY`, `AttributeName::VALUE_OBJECT`, etc. (src/Forbidden.php:31-50)
+
+- Attribute / tag handling depends on external `xmolecules/phpmolecules` package (README usage, composer.json:25-26). Tests use attributes on fixture classes in `tests/Data`.
+
+- Analyzer implementation is under `src/Analyzer/` — multiple classes for parsing PHP files and reducing relations. Use these files when modifying or extending analysis.
+
+## Naming conventions and code-style patterns (observed)
+
+- PSR-4 namespaces: `Tactix\` for src/, `Tactix\Tests\` for tests (composer.json:6-14)
+- Strict types declaration: files declare `declare(strict_types=1);` (many files)
+- Readonly classes: some classes use `final readonly class` (src/Check.php:7)
+- Exceptions follow `*Exception` suffix and are placed in project root (e.g. `ClassViolationException.php`)
+- Test methods use descriptive names and `#[Test]` attribute (tests/Unit/*)
+
+## Files to inspect when making changes
+
+- Public API: `src/Check.php` (src/Check.php:7-31)
+- Violation models & exceptions: `src/Violation.php`, `src/ViolationException.php`, `src/ClassViolationException.php`, `src/FolderViolationException.php`
+- Forbidden rules: `src/Forbidden.php` (src/Forbidden.php:19-51)
+- Analyzer logic: `src/Analyzer/*` (multiple files)
+- Tests & fixtures: `tests/Unit/*`, `tests/Data/*`
+- CI workflow: `.github/workflows/app-ci.yaml`
+- Static analysis: `phpstan.neon.dist`
+- Composer scripts: `composer.json:scripts`
+
+## Gotchas and non-obvious observations (explicit)
+
+- `Forbidden::check` will throw a `LogicException` if a "from" `AttributeName` is not present in the hard-coded blacklist (src/Forbidden.php:27). If you add a new `AttributeName` you must also update the blacklist or handle the exception.
+
+- Composer `qa` script runs the fixer with `vendor/bin/php-cs-fixer fix` which will modify files in-place. CI runs `php-cs-fixer check` (app-ci.yaml:40) which only checks; the `composer qa` usage differs (fix vs check).
+
+- PHPUnit is configured to stop on error (phpunit.xml.dist:9) and has xdebug coverage settings enabled in the configuration file (phpunit.xml.dist:19-20).
+
+- Tests rely on autoloading and the test bootstrap `tests/bootstrap.php` which calls the Composer autoloader (tests/bootstrap.php:3). Ensure composer dependencies are installed before running tests.
+
+## What I searched for (discovery steps performed)
+
+- repo root listing (ls)
+- looked for agent/rule files: none found
+- composer.json (read for scripts, autoload, requirements)
+- phpunit.xml.dist (read for test config)
+- phpstan.neon.dist (read for static analysis config)
+- README.md (usage notes and examples)
+- .github/workflows/app-ci.yaml (CI steps)
+- representative source files: src/Check.php, src/Forbidden.php, src/Analyzer/*
+- tests: tests/Unit/* and tests/Data/*
+
+---
+
+If you want this file updated (expanded, reorganized, or to include additional file:line references), run this command again and specify what to add.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+CONTAINER_NAME ?= tactix
+
+.PHONY: build up down test shell
+
+build:
+	@docker compose build --pull --no-cache
+
+up:
+	@docker compose up -d --remove-orphans
+
+down:
+	@docker compose down
+
+# Run PHPUnit inside the container (starts a one-off container if not running)
+test:
+	@docker compose run --rm php vendor/bin/phpunit --configuration phpunit.xml.dist $(TESTARGS)
+
+# Open an interactive shell in the running container
+shell:
+	@docker exec -it $(CONTAINER_NAME) sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requirements:
 
 ### 1. Tag your classes
 
-- install the tags package from PHP Molecules as a regular dependeny via:
+- install the tags package from PHP Molecules as a regular dependency via:
 
 ```bash
 composer require xmolecules/phpmolecules

--- a/README.md
+++ b/README.md
@@ -64,3 +64,28 @@ Tactix includes a small built-in blacklist (see `Tactix\Forbidden`) and reports 
 ```
 (MyValueObject)-[consumes]->(MyEntity) is a forbidden relation! ❌
 ```
+
+## Container-based workflow
+
+This repository includes a lightweight container workflow to run tests and analysis in a reproducible environment.
+
+- Build image: `make build` (requires Docker and Docker Compose v2+)
+- Start service: `make up`
+- Install dependencies inside container: `docker exec -u 1000 tactix sh -c 'cd /var/www/project && composer install --no-interaction'`
+- Run tests in container: `make test` or `docker exec -u 1000 tactix sh -c 'cd /var/www/project && vendor/bin/phpunit --configuration phpunit.xml.dist --testdox'`
+- Open shell in running container: `make shell`
+
+Notes:
+- The container mounts the repository at `/var/www/project` and runs as UID 1000:GID 1001.
+- The Dockerfile used is at `docker/php/Dockerfile` and is based on the official `php:8.4-cli` image. It installs Composer and Xdebug to allow coverage reporting.
+
+## Contributing
+
+Guidelines for contributing improvements:
+
+- Run the QA suite locally before opening a PR: `composer qa` (runs PHPStan, php-cs-fixer and PHPUnit).
+- Prefer adding unit tests for new features or bug fixes; tests are in `tests/Unit`.
+- Follow PHPStan and php-cs-fixer rules. Running `composer cs` will apply fixer changes.
+- If you use the container workflow, prefer running tests inside the container to match CI.
+- Open pull requests targeting the `master` branch with a clear description of the change and a short test plan.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  tactix:
+    build:
+      context: ./docker/php
+      dockerfile: Dockerfile
+    container_name: tactix
+    working_dir: /var/www/project
+    volumes:
+      - ./:/var/www/project
+    user: "1000:1001"
+    environment:
+      - XDEBUG_MODE=coverage
+    tty: true
+    command: tail -f /dev/null

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.4-cli
+
+# Install common extensions and tools used in tests and by composer
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip zlib1g-dev libzip-dev libxml2-dev \
+    && docker-php-ext-install zip pcntl
+
+# Xdebug for coverage (optional)
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/project

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
          backupGlobals="false"
          colors="true"
          bootstrap="tests/bootstrap.php"
-         stopOnError="true"
+         stopOnError="false"
 >
     <php>
         <ini name="display_errors" value="On" />

--- a/src/Analyzer/Class/ReturnTypeFactory.php
+++ b/src/Analyzer/Class/ReturnTypeFactory.php
@@ -41,7 +41,7 @@ final readonly class ReturnTypeFactory
             );
         }
 
-        throw new \LogicException(sprintf('"%s" (e.g. type union or type intersection) is not yet supported', get_debug_type($returnType)));
+        throw new \LogicException(sprintf('"%s" (unions and intersections) are not supported', get_debug_type($returnType)));
     }
 
     private static function getDocBlockReturnType(ClassMethod $method): ?string

--- a/src/Analyzer/Class/ReturnTypeFactory.php
+++ b/src/Analyzer/Class/ReturnTypeFactory.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Analyzer\Class;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\ClassMethod;
+use Tactix\Analyzer\DocTypeExtractor;
+
+final readonly class ReturnTypeFactory
+{
+    public static function fromMethod(ClassMethod $method): ReturnType
+    {
+        $docReturnType = self::getDocBlockReturnType($method);
+        $collectionDocType = DocTypeExtractor::resolveCollectionDocType($docReturnType);
+        $generatorDocType = DocTypeExtractor::resolveGeneratorDocType($docReturnType);
+
+        if (is_null($method->returnType)) {
+            if ($collectionDocType) {
+                return ReturnType::collection(new Name($collectionDocType, NameType::UNKNOWN));
+            }
+            if ($generatorDocType) {
+                return ReturnType::generator(new Name($generatorDocType, NameType::UNKNOWN));
+            }
+            if (is_string($docReturnType)) {
+                return ReturnType::regular(new Name($docReturnType, NameType::UNKNOWN));
+            }
+
+            return ReturnType::void();
+        }
+
+        $returnType = $method->returnType;
+        if ($returnType instanceof Identifier || $returnType instanceof \PhpParser\Node\Name || $returnType instanceof NullableType) {
+            return self::fromString(
+                (string) ($returnType instanceof NullableType ? $returnType->type : $returnType),
+                $returnType instanceof NullableType,
+                $collectionDocType,
+                $generatorDocType
+            );
+        }
+
+        throw new \LogicException(sprintf('"%s" (e.g. type union or type intersection) is not yet supported', get_debug_type($returnType)));
+    }
+
+    private static function getDocBlockReturnType(ClassMethod $method): ?string
+    {
+        $docComment = $method->getDocComment();
+        if (null === $docComment) {
+            return null;
+        }
+
+        if (!preg_match('/@return\s+([^\s]+)/', $docComment->getText(), $matches)) {
+            return null;
+        }
+
+        return trim($matches[1]);
+    }
+
+    private static function fromString(string $typeName, bool $nullable, ?string $collectionDocType, ?string $generatorDocType): ReturnType
+    {
+        if ('void' === $typeName) {
+            return ReturnType::void();
+        }
+        $collectionOrGenerator = self::extractCollectionOrGenerator($typeName);
+        if ('collection' === $collectionOrGenerator) {
+            if (null !== $collectionDocType) {
+                return ReturnType::collection(new Name($collectionDocType, NameType::UNKNOWN));
+            }
+
+            return ReturnType::unknown();
+        }
+        if ('generator' === $collectionOrGenerator) {
+            if (null !== $generatorDocType) {
+                return ReturnType::generator(new Name($generatorDocType, NameType::UNKNOWN));
+            }
+
+            return ReturnType::unknown();
+        }
+
+        return $nullable
+            ? ReturnType::nullable(new Name($typeName, NameType::UNKNOWN))
+            : ReturnType::regular(new Name($typeName, NameType::UNKNOWN));
+    }
+
+    private static function extractCollectionOrGenerator(string $type): ?string
+    {
+        $type = ltrim($type, '\\');
+        if (in_array($type, ['array', 'list', 'iterable'], true)) {
+            return 'collection';
+        }
+        if ('Generator' === $type) {
+            return 'generator';
+        }
+
+        return null;
+    }
+}

--- a/src/Analyzer/ClassAnalyzer.php
+++ b/src/Analyzer/ClassAnalyzer.php
@@ -339,19 +339,17 @@ final class ClassAnalyzer extends NodeVisitorAbstract
             return ReturnType::void();
         }
 
-        if (self::isCollectionTypeName($typeName)) {
+        $specialType = self::isSpecialTypeName($typeName);
+        if ($specialType === 'collection') {
             if (null !== $collectionDocType) {
                 return ReturnType::collection(new AnalyzerClassName($collectionDocType, NameType::UNKNOWN));
             }
-
             return ReturnType::unknown();
         }
-
-        if (self::isGeneratorTypeName($typeName)) {
+        if ($specialType === 'generator') {
             if (null !== $generatorDocType) {
                 return ReturnType::generator(new AnalyzerClassName($generatorDocType, NameType::UNKNOWN));
             }
-
             return ReturnType::unknown();
         }
 
@@ -360,14 +358,16 @@ final class ClassAnalyzer extends NodeVisitorAbstract
             : ReturnType::regular(new AnalyzerClassName($typeName, NameType::UNKNOWN));
     }
 
-    private static function isCollectionTypeName(string $type): bool
+    private static function isSpecialTypeName(string $type): ?string
     {
-        return in_array(ltrim($type, '\\'), ['array', 'list', 'iterable'], true);
-    }
-
-    private static function isGeneratorTypeName(string $type): bool
-    {
-        return in_array(ltrim($type, '\\'), ['Generator'], true);
+        $type = ltrim($type, '\\');
+        if (in_array($type, ['array', 'list', 'iterable'], true)) {
+            return 'collection';
+        }
+        if ($type === 'Generator') {
+            return 'generator';
+        }
+        return null;
     }
 
     private static function getDocBlockReturnType(ClassMethod $method): ?string

--- a/src/Analyzer/ClassAnalyzer.php
+++ b/src/Analyzer/ClassAnalyzer.php
@@ -158,19 +158,6 @@ final class ClassAnalyzer extends NodeVisitorAbstract
         return new Argument($name, $type, $isNullable, $isCollection);
     }
 
-    // private static function isSpecialTypeName(string $type): ?string
-    // {
-    //     $type = ltrim($type, '\\');
-    //     if (in_array($type, ['array', 'list', 'iterable'], true)) {
-    //         return 'collection';
-    //     }
-    //     if ('Generator' === $type) {
-    //         return 'generator';
-    //     }
-
-    //     return null;
-    // }
-
     private static function getTypeAsString(?Node $node): string
     {
         if ($node instanceof NullableType) {

--- a/src/Analyzer/ClassAnalyzer.php
+++ b/src/Analyzer/ClassAnalyzer.php
@@ -250,11 +250,11 @@ final class ClassAnalyzer extends NodeVisitorAbstract
             return rtrim(substr($docType, 0, -2));
         }
 
-        if (preg_match('/^(?:array|list|iterable)<\s*([^,>]+)\s*>$/i', $docType, $matches)) {
+        if (preg_match('/^(?:\\\\?array|\\\\?list|\\\\?iterable)<\s*([^,>]+)\s*>$/i', $docType, $matches)) {
             return trim($matches[1]);
         }
 
-        if (preg_match('/^(?:array|list|iterable)<\s*[^,>]+,\s*([^>]+)\s*>$/i', $docType, $matches)) {
+        if (preg_match('/^(?:\\\\?array|\\\\?list|\\\\?iterable)<\s*[^,>]+,\s*([^>]+)\s*>$/i', $docType, $matches)) {
             return trim($matches[1]);
         }
 

--- a/src/Analyzer/ClassAnalyzer.php
+++ b/src/Analyzer/ClassAnalyzer.php
@@ -159,51 +159,21 @@ final class ClassAnalyzer extends NodeVisitorAbstract
         $returnType = $method->returnType;
 
         if ($returnType instanceof Identifier || $returnType instanceof Name) {
-            $typeName = (string) $returnType;
-
-            if ('void' === $typeName) {
-                return ReturnType::void();
-            }
-
-            if (self::isCollectionTypeName($typeName)) {
-                if (null !== $collectionDocType) {
-                    return ReturnType::collection(new AnalyzerClassName($collectionDocType, NameType::UNKNOWN));
-                }
-
-                return ReturnType::unknown();
-            }
-
-            if (self::isGeneratorTypeName($typeName)) {
-                if (null !== $generatorDocType) {
-                    return ReturnType::generator(new AnalyzerClassName($generatorDocType, NameType::UNKNOWN));
-                }
-
-                return ReturnType::unknown();
-            }
-
-            return ReturnType::regular(new AnalyzerClassName($typeName, NameType::UNKNOWN));
+            return self::createReturnTypeFromString(
+                (string) $returnType,
+                false,
+                $collectionDocType,
+                $generatorDocType
+            );
         }
 
         if ($returnType instanceof NullableType) {
-            $typeName = (string) $returnType->type;
-
-            if (self::isCollectionTypeName($typeName)) {
-                if (null !== $collectionDocType) {
-                    return ReturnType::collection(new AnalyzerClassName($collectionDocType, NameType::UNKNOWN));
-                }
-
-                return ReturnType::unknown();
-            }
-
-            if (self::isGeneratorTypeName($typeName)) {
-                if (null !== $generatorDocType) {
-                    return ReturnType::generator(new AnalyzerClassName($generatorDocType, NameType::UNKNOWN));
-                }
-
-                return ReturnType::unknown();
-            }
-
-            return ReturnType::nullable(new AnalyzerClassName($typeName, NameType::UNKNOWN));
+            return self::createReturnTypeFromString(
+                (string) $returnType->type,
+                true,
+                $collectionDocType,
+                $generatorDocType
+            );
         }
 
         if ($returnType instanceof UnionType || $returnType instanceof IntersectionType) {
@@ -361,6 +331,33 @@ final class ClassAnalyzer extends NodeVisitorAbstract
     private static function isCollectionDoc(string $docType): bool
     {
         return null !== self::resolveCollectionDocType($docType);
+    }
+
+    private static function createReturnTypeFromString(string $typeName, bool $nullable, ?string $collectionDocType, ?string $generatorDocType): ReturnType
+    {
+        if ('void' === $typeName) {
+            return ReturnType::void();
+        }
+
+        if (self::isCollectionTypeName($typeName)) {
+            if (null !== $collectionDocType) {
+                return ReturnType::collection(new AnalyzerClassName($collectionDocType, NameType::UNKNOWN));
+            }
+
+            return ReturnType::unknown();
+        }
+
+        if (self::isGeneratorTypeName($typeName)) {
+            if (null !== $generatorDocType) {
+                return ReturnType::generator(new AnalyzerClassName($generatorDocType, NameType::UNKNOWN));
+            }
+
+            return ReturnType::unknown();
+        }
+
+        return $nullable
+            ? ReturnType::nullable(new AnalyzerClassName($typeName, NameType::UNKNOWN))
+            : ReturnType::regular(new AnalyzerClassName($typeName, NameType::UNKNOWN));
     }
 
     private static function isCollectionTypeName(string $type): bool

--- a/src/Analyzer/DocTypeExtractor.php
+++ b/src/Analyzer/DocTypeExtractor.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Analyzer;
+
+use PhpParser\Node\Stmt\ClassMethod;
+
+final class DocTypeExtractor
+{
+    /**
+     * Returns a map of parameter name to parameter type.
+     *
+     * @return array<string, string>
+     */
+    public static function getDocBlockParamTypes(ClassMethod $method): array
+    {
+        $docComment = $method->getDocComment();
+        if (null === $docComment) {
+            return [];
+        }
+
+        $doc = $docComment->getText();
+        preg_match_all('/@param\s+([^\s]+)\s+\$([^\s]+)/', $doc, $matches, PREG_SET_ORDER);
+
+        $types = [];
+        foreach ($matches as $match) {
+            $paramName = $match[2];
+            $type = $match[1];
+            $types[$paramName] = $type;
+        }
+
+        return $types;
+    }
+
+    public static function getDocBlockReturnType(ClassMethod $method): ?string
+    {
+        $docComment = $method->getDocComment();
+        if (null === $docComment) {
+            return null;
+        }
+
+        if (!preg_match('/@return\s+([^\s]+)/', $docComment->getText(), $matches)) {
+            return null;
+        }
+
+        return trim($matches[1]);
+    }
+
+    public static function resolveCollectionDocType(?string $docType): ?string
+    {
+        if (null === $docType) {
+            return null;
+        }
+
+        $docType = trim($docType);
+        if ('' === $docType) {
+            return null;
+        }
+
+        $docType = trim(explode('|', $docType)[0]);
+        if ('' === $docType) {
+            return null;
+        }
+
+        if (str_ends_with($docType, '[]')) {
+            return rtrim(substr($docType, 0, -2));
+        }
+
+        if (preg_match('/^(?:\\\\?array|\\\\?list|\\\\?iterable)<\s*([^,>]+)\s*>$/i', $docType, $matches)) {
+            return trim($matches[1]);
+        }
+
+        if (preg_match('/^(?:\\\\?array|\\\\?list|\\\\?iterable)<\s*[^,>]+,\s*([^>]+)\s*>$/i', $docType, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+
+    public static function resolveGeneratorDocType(?string $docType): ?string
+    {
+        if (null === $docType) {
+            return null;
+        }
+
+        $docType = trim($docType);
+        if ('' === $docType) {
+            return null;
+        }
+
+        $docType = trim(explode('|', $docType)[0]);
+        if ('' === $docType) {
+            return null;
+        }
+
+        if (!preg_match('/^(?:\\\\)?Generator<(.+)>$/i', $docType, $matches)) {
+            return null;
+        }
+
+        $parameters = self::splitGenericParameters($matches[1]);
+        if (empty($parameters)) {
+            return null;
+        }
+
+        return trim($parameters[1] ?? $parameters[0]);
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function splitGenericParameters(string $typeList): array
+    {
+        $parts = [];
+        $current = '';
+        $depth = 0;
+        $length = strlen($typeList);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $typeList[$i];
+
+            if (',' === $char && 0 === $depth) {
+                $trimmed = trim($current);
+                if ('' !== $trimmed) {
+                    $parts[] = $trimmed;
+                }
+                $current = '';
+                continue;
+            }
+
+            if ('<' === $char) {
+                ++$depth;
+            } elseif ('>' === $char && $depth > 0) {
+                --$depth;
+            }
+
+            $current .= $char;
+        }
+
+        $trimmed = trim($current);
+        if ('' !== $trimmed) {
+            $parts[] = $trimmed;
+        }
+
+        return $parts;
+    }
+}

--- a/tests/Data/MyCollection.php
+++ b/tests/Data/MyCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyCollection
+{
+    /**
+     * @param MyValueObject[] $collection
+     */
+    public function __construct(public array $collection)
+    {
+    }
+}

--- a/tests/Data/MyConsumesArray.php
+++ b/tests/Data/MyConsumesArray.php
@@ -7,12 +7,13 @@ namespace Tactix\Tests\Data;
 use PHPMolecules\DDD\Attribute\ValueObject;
 
 #[ValueObject]
-final readonly class MyCollection
+final readonly class MyConsumesArray
 {
     /**
      * @param MyValueObject[] $collection
      */
-    public function __construct(public array $collection)
+    public function consumes(array $collection): void
     {
+        throw new \Exception('Not yet implemented!');
     }
 }

--- a/tests/Data/MyConsumesArray.php
+++ b/tests/Data/MyConsumesArray.php
@@ -12,7 +12,7 @@ final readonly class MyConsumesArray
     /**
      * @param MyValueObject[] $collection
      */
-    public function consumes(array $collection): void
+    public function consume(array $collection): void
     {
         throw new \Exception('Not yet implemented!');
     }

--- a/tests/Data/MyConsumesArrayTemplate.php
+++ b/tests/Data/MyConsumesArrayTemplate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyConsumesArrayTemplate
+{
+    /**
+     * @param array<MyValueObject> $collection
+     */
+    public function consumes(array $collection): void
+    {
+        throw new \Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyConsumesArrayTemplate.php
+++ b/tests/Data/MyConsumesArrayTemplate.php
@@ -12,7 +12,7 @@ final readonly class MyConsumesArrayTemplate
     /**
      * @param array<MyValueObject> $collection
      */
-    public function consumes(array $collection): void
+    public function consume(array $collection): void
     {
         throw new \Exception('Not yet implemented!');
     }

--- a/tests/Data/MyConsumesIterable.php
+++ b/tests/Data/MyConsumesIterable.php
@@ -12,7 +12,7 @@ final readonly class MyConsumesIterable
     /**
      * @param iterable<MyValueObject> $collection
      */
-    public function consumes(iterable $collection): void
+    public function consume(iterable $collection): void
     {
         throw new \Exception('Not yet implemented!');
     }

--- a/tests/Data/MyConsumesIterable.php
+++ b/tests/Data/MyConsumesIterable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyConsumesIterable
+{
+    /**
+     * @param iterable<MyValueObject> $collection
+     */
+    public function consumes(iterable $collection): void
+    {
+        throw new \Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyConsumesList.php
+++ b/tests/Data/MyConsumesList.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyConsumesList
+{
+    /**
+     * @param list<MyValueObject> $collection
+     */
+    public function consumes(array $collection): void
+    {
+        throw new \Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyConsumesList.php
+++ b/tests/Data/MyConsumesList.php
@@ -12,7 +12,7 @@ final readonly class MyConsumesList
     /**
      * @param list<MyValueObject> $collection
      */
-    public function consumes(array $collection): void
+    public function consume(array $collection): void
     {
         throw new \Exception('Not yet implemented!');
     }

--- a/tests/Data/MyProducesArray.php
+++ b/tests/Data/MyProducesArray.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tactix\Tests\Data;
 
-use Exception;
 use PHPMolecules\DDD\Attribute\ValueObject;
 
 #[ValueObject]
@@ -15,6 +14,6 @@ final readonly class MyProducesArray
      */
     public function produce(): array
     {
-        throw new Exception('Not yet implemented!');
+        throw new \Exception('Not yet implemented!');
     }
 }

--- a/tests/Data/MyProducesArray.php
+++ b/tests/Data/MyProducesArray.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use Exception;
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyProducesArray
+{
+    /**
+     * @return MyValueObject[]
+     */
+    public function produce(): array
+    {
+        throw new Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyProducesArrayTemplate.php
+++ b/tests/Data/MyProducesArrayTemplate.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use Exception;
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyProducesArrayTemplate
+{
+    /**
+     * @return array<MyValueObject>
+     */
+    public function produce(): array
+    {
+        throw new Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyProducesArrayTemplate.php
+++ b/tests/Data/MyProducesArrayTemplate.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tactix\Tests\Data;
 
-use Exception;
 use PHPMolecules\DDD\Attribute\ValueObject;
 
 #[ValueObject]
@@ -15,6 +14,6 @@ final readonly class MyProducesArrayTemplate
      */
     public function produce(): array
     {
-        throw new Exception('Not yet implemented!');
+        throw new \Exception('Not yet implemented!');
     }
 }

--- a/tests/Data/MyProducesGenerator.php
+++ b/tests/Data/MyProducesGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use PHPMolecules\DDD\Attribute\AggregateRoot;
+
+#[AggregateRoot]
+final readonly class MyProducesGenerator
+{
+    /**
+     * @return \Generator<MyValueObject>
+     */
+    public function produceValueObjects(): \Generator
+    {
+        throw new \Exception('Not yet implemented!');
+    }
+
+    /**
+     * @return \Generator<MyEntity>
+     */
+    public function produceEntities(): \Generator
+    {
+        throw new \Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyProducesIterable.php
+++ b/tests/Data/MyProducesIterable.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tactix\Tests\Data;
 
-use Exception;
 use PHPMolecules\DDD\Attribute\ValueObject;
 
 #[ValueObject]
@@ -13,8 +12,8 @@ final readonly class MyProducesIterable
     /**
      * @return iterable<MyValueObject>
      */
-    public function produce(): \Generator
+    public function produce(): iterable
     {
-        throw new Exception('Not yet implemented!');
+        throw new \Exception('Not yet implemented!');
     }
 }

--- a/tests/Data/MyProducesIterable.php
+++ b/tests/Data/MyProducesIterable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use Exception;
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyProducesIterable
+{
+    /**
+     * @return iterable<MyValueObject>
+     */
+    public function produce(): \Generator
+    {
+        throw new Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyProducesList.php
+++ b/tests/Data/MyProducesList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Data;
+
+use Exception;
+use PHPMolecules\DDD\Attribute\ValueObject;
+
+#[ValueObject]
+final readonly class MyProducesList
+{
+    /**
+     * @return list<MyValueObject>
+     */
+    public function produce(): array
+    {
+        throw new Exception('Not yet implemented!');
+    }
+}

--- a/tests/Data/MyProducesList.php
+++ b/tests/Data/MyProducesList.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tactix\Tests\Data;
 
-use Exception;
 use PHPMolecules\DDD\Attribute\ValueObject;
 
 #[ValueObject]
@@ -15,6 +14,6 @@ final readonly class MyProducesList
      */
     public function produce(): array
     {
-        throw new Exception('Not yet implemented!');
+        throw new \Exception('Not yet implemented!');
     }
 }

--- a/tests/Unit/CollectionTest.php
+++ b/tests/Unit/CollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tactix\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tactix\Analyzer\Edge;
+use Tactix\Analyzer\Relation;
+use Tactix\Analyzer\YieldRelations;
+use Tactix\Tests\Data\MyCollection;
+use Tactix\Tests\Data\MyValueObject;
+
+class CollectionTest extends TestCase
+{
+    #[Test]
+    public function consume_collection_should_return_type(): void
+    {
+        $relations = iterator_to_array(YieldRelations::fromClassName(MyCollection::class));
+
+        $first = $relations[0];
+        assert($first instanceof Relation);
+
+        self::assertEquals($first->edge, Edge::CONSUMES);
+        self::assertSame(MyValueObject::class, $first->to->fqcn);
+    }
+}

--- a/tests/Unit/CollectionTest.php
+++ b/tests/Unit/CollectionTest.php
@@ -14,6 +14,10 @@ use Tactix\Tests\Data\MyConsumesArray;
 use Tactix\Tests\Data\MyConsumesArrayTemplate;
 use Tactix\Tests\Data\MyConsumesIterable;
 use Tactix\Tests\Data\MyConsumesList;
+use Tactix\Tests\Data\MyProducesArray;
+use Tactix\Tests\Data\MyProducesArrayTemplate;
+use Tactix\Tests\Data\MyProducesIterable;
+use Tactix\Tests\Data\MyProducesList;
 use Tactix\Tests\Data\MyValueObject;
 
 class CollectionTest extends TestCase
@@ -22,29 +26,60 @@ class CollectionTest extends TestCase
      * @param class-string $fromClassName
      */
     #[Test]
-    #[DataProvider('provideTestData')]
-    public function consumes_array(string $fromClassName): void
+    #[DataProvider('provideConsumingClasses')]
+    public function consumes_collection(string $fromClassName): void
     {
         $relations = iterator_to_array(YieldRelations::fromClassName($fromClassName));
 
         /** @var Relation $relation */
         $relation = $relations[0];
 
+        self::assertInstanceOf(Relation::class, $relation);
         self::assertSame($fromClassName, $relation->from->fqcn);
         self::assertEquals($relation->edge, Edge::CONSUMES);
+        self::assertSame(MyValueObject::class, $relation->to->fqcn);
+    }
+    /**
+     * @param class-string $fromClassName
+     */
+    #[Test]
+    #[DataProvider('provideProducingClasses')]
+    public function produces_collection(string $fromClassName): void
+    {
+        $relations = iterator_to_array(YieldRelations::fromClassName($fromClassName));
+
+        /** @var Relation $relation */
+        $relation = $relations[0];
+
+        self::assertInstanceOf(Relation::class, $relation);
+        self::assertSame($fromClassName, $relation->from->fqcn);
+        self::assertEquals($relation->edge, Edge::PRODUCES);
         self::assertSame(MyValueObject::class, $relation->to->fqcn);
     }
 
     /**
      * @return array<int, string[]>
      */
-    public static function provideTestData(): array
+    public static function provideConsumingClasses(): array
     {
         return [
             [MyConsumesArray::class],
             [MyConsumesArrayTemplate::class],
             [MyConsumesList::class],
             [MyConsumesIterable::class],
+        ];
+    }
+
+    /**
+     * @return array<int, string[]>
+     */
+    public static function provideProducingClasses(): array
+    {
+        return [
+            [MyProducesArray::class],
+            [MyProducesArrayTemplate::class],
+            [MyProducesList::class],
+            [MyProducesIterable::class],
         ];
     }
 }

--- a/tests/Unit/CollectionTest.php
+++ b/tests/Unit/CollectionTest.php
@@ -34,6 +34,8 @@ class CollectionTest extends TestCase
     {
         $relations = iterator_to_array(YieldRelations::fromClassName($fromClassName));
 
+        self::assertSameSize($toClassNames, $relations);
+
         foreach ($relations as $relation) {
             self::assertInstanceOf(Relation::class, $relation);
             self::assertSame($fromClassName, $relation->from->fqcn);
@@ -51,6 +53,8 @@ class CollectionTest extends TestCase
     public function produces_collection(string $fromClassName, Edge $expectedEdge, array $toClassNames): void
     {
         $relations = iterator_to_array(YieldRelations::fromClassName($fromClassName));
+
+        self::assertSameSize($toClassNames, $relations);
 
         foreach ($relations as $relation) {
             self::assertInstanceOf(Relation::class, $relation);
@@ -83,7 +87,7 @@ class CollectionTest extends TestCase
             [MyProducesArrayTemplate::class, Edge::PRODUCES, [MyValueObject::class]],
             [MyProducesList::class, Edge::PRODUCES, [MyValueObject::class]],
             [MyProducesIterable::class, Edge::PRODUCES, [MyValueObject::class]],
-            // [MyProducesGenerator::class, Edge::PRODUCES, [MyValueObject::class, MyEntity::class]],
+            [MyProducesGenerator::class, Edge::PRODUCES, [MyValueObject::class, MyEntity::class]],
         ];
     }
 }

--- a/tests/Unit/CollectionTest.php
+++ b/tests/Unit/CollectionTest.php
@@ -14,8 +14,10 @@ use Tactix\Tests\Data\MyConsumesArray;
 use Tactix\Tests\Data\MyConsumesArrayTemplate;
 use Tactix\Tests\Data\MyConsumesIterable;
 use Tactix\Tests\Data\MyConsumesList;
+use Tactix\Tests\Data\MyEntity;
 use Tactix\Tests\Data\MyProducesArray;
 use Tactix\Tests\Data\MyProducesArrayTemplate;
+use Tactix\Tests\Data\MyProducesGenerator;
 use Tactix\Tests\Data\MyProducesIterable;
 use Tactix\Tests\Data\MyProducesList;
 use Tactix\Tests\Data\MyValueObject;
@@ -23,63 +25,65 @@ use Tactix\Tests\Data\MyValueObject;
 class CollectionTest extends TestCase
 {
     /**
-     * @param class-string $fromClassName
+     * @param class-string   $fromClassName
+     * @param class-string[] $toClassNames
      */
     #[Test]
     #[DataProvider('provideConsumingClasses')]
-    public function consumes_collection(string $fromClassName): void
+    public function consumes_collection(string $fromClassName, Edge $expectedEdge, array $toClassNames): void
     {
         $relations = iterator_to_array(YieldRelations::fromClassName($fromClassName));
 
-        /** @var Relation $relation */
-        $relation = $relations[0];
-
-        self::assertInstanceOf(Relation::class, $relation);
-        self::assertSame($fromClassName, $relation->from->fqcn);
-        self::assertEquals($relation->edge, Edge::CONSUMES);
-        self::assertSame(MyValueObject::class, $relation->to->fqcn);
+        foreach ($relations as $relation) {
+            self::assertInstanceOf(Relation::class, $relation);
+            self::assertSame($fromClassName, $relation->from->fqcn);
+            self::assertEquals($expectedEdge, $relation->edge);
+            self::assertTrue(in_array($relation->to->fqcn, $toClassNames, strict: true));
+        }
     }
+
     /**
-     * @param class-string $fromClassName
+     * @param class-string   $fromClassName
+     * @param class-string[] $toClassNames
      */
     #[Test]
     #[DataProvider('provideProducingClasses')]
-    public function produces_collection(string $fromClassName): void
+    public function produces_collection(string $fromClassName, Edge $expectedEdge, array $toClassNames): void
     {
         $relations = iterator_to_array(YieldRelations::fromClassName($fromClassName));
 
-        /** @var Relation $relation */
-        $relation = $relations[0];
-
-        self::assertInstanceOf(Relation::class, $relation);
-        self::assertSame($fromClassName, $relation->from->fqcn);
-        self::assertEquals($relation->edge, Edge::PRODUCES);
-        self::assertSame(MyValueObject::class, $relation->to->fqcn);
+        foreach ($relations as $relation) {
+            self::assertInstanceOf(Relation::class, $relation);
+            self::assertSame($fromClassName, $relation->from->fqcn);
+            self::assertSame($expectedEdge, $relation->edge);
+            self::assertTrue(in_array($relation->to->fqcn, $toClassNames, strict: true));
+        }
     }
 
     /**
-     * @return array<int, string[]>
+     * @return array<int, array{class-string, Edge, class-string[]}>
      */
     public static function provideConsumingClasses(): array
     {
         return [
-            [MyConsumesArray::class],
-            [MyConsumesArrayTemplate::class],
-            [MyConsumesList::class],
-            [MyConsumesIterable::class],
+            [MyConsumesArray::class, Edge::CONSUMES, [MyValueObject::class]],
+            [MyConsumesArrayTemplate::class, Edge::CONSUMES, [MyValueObject::class]],
+            [MyConsumesList::class, Edge::CONSUMES, [MyValueObject::class]],
+            [MyConsumesIterable::class, Edge::CONSUMES, [MyValueObject::class]],
         ];
     }
 
     /**
-     * @return array<int, string[]>
+     * @return array<int, array{class-string, Edge, class-string[]}>
      */
     public static function provideProducingClasses(): array
     {
         return [
-            [MyProducesArray::class],
-            [MyProducesArrayTemplate::class],
-            [MyProducesList::class],
-            [MyProducesIterable::class],
+            [MyProducesArray::class, Edge::PRODUCES, [MyValueObject::class]],
+            [MyProducesArrayTemplate::class, Edge::PRODUCES, [MyValueObject::class]],
+            [MyProducesList::class, Edge::PRODUCES, [MyValueObject::class]],
+            [MyProducesIterable::class, Edge::PRODUCES, [MyValueObject::class]],
+            // [MyProducesGenerator::class, Edge::PRODUCES, [MyValueObject::class, MyEntity::class]],
         ];
     }
 }

--- a/tests/Unit/CollectionTest.php
+++ b/tests/Unit/CollectionTest.php
@@ -4,25 +4,47 @@ declare(strict_types=1);
 
 namespace Tactix\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Tactix\Analyzer\Edge;
 use Tactix\Analyzer\Relation;
 use Tactix\Analyzer\YieldRelations;
-use Tactix\Tests\Data\MyCollection;
+use Tactix\Tests\Data\MyConsumesArray;
+use Tactix\Tests\Data\MyConsumesArrayTemplate;
+use Tactix\Tests\Data\MyConsumesIterable;
+use Tactix\Tests\Data\MyConsumesList;
 use Tactix\Tests\Data\MyValueObject;
 
 class CollectionTest extends TestCase
 {
+    /**
+     * @param class-string $fromClassName
+     */
     #[Test]
-    public function consume_collection_should_return_type(): void
+    #[DataProvider('provideTestData')]
+    public function consumes_array(string $fromClassName): void
     {
-        $relations = iterator_to_array(YieldRelations::fromClassName(MyCollection::class));
+        $relations = iterator_to_array(YieldRelations::fromClassName($fromClassName));
 
-        $first = $relations[0];
-        assert($first instanceof Relation);
+        /** @var Relation $relation */
+        $relation = $relations[0];
 
-        self::assertEquals($first->edge, Edge::CONSUMES);
-        self::assertSame(MyValueObject::class, $first->to->fqcn);
+        self::assertSame($fromClassName, $relation->from->fqcn);
+        self::assertEquals($relation->edge, Edge::CONSUMES);
+        self::assertSame(MyValueObject::class, $relation->to->fqcn);
+    }
+
+    /**
+     * @return array<int, string[]>
+     */
+    public static function provideTestData(): array
+    {
+        return [
+            [MyConsumesArray::class],
+            [MyConsumesArrayTemplate::class],
+            [MyConsumesList::class],
+            [MyConsumesIterable::class],
+        ];
     }
 }


### PR DESCRIPTION
The following collection type annotations are now supported:

- `array<MyType>`
- `MyType[]`
- `list<MyType>`
- `iterable<MyType>`